### PR TITLE
feat: add starting index and event to fire when transition is finished

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ The `BackgroundSlideshow` component will have `position: absolute` and sized to 
 - `props.disableInterval` - boolean, optional disables automated automation at interval specified by `automationDelay` (default `false`)
 - `props.animationDelay` - number, optional specifies the interval in ms for transitions while idle (default `10000`)
 - `props.alt` - string, optional specifies the alt attribute to use for the underlying `<img>` elements (default `background slideshow`)
+- `props.startAt` - number, optional specifies the index to start the slideshow at. By default will randomly select one.
+- `props.onChange` - function, optional specifies the callback to call when the transition is complete. This is sent the argument { index: number, image: string }. `index` is the `props.images` index the slideshow is showing. `image` is the image url from `images` being shown after the change.
 
 **Note** I highly recommend using background images with a resolution of 1280x850. The effects have not been tested thoroughly with other asset sizes and there is a possibility that other aspect ratios break some of the internal assumptions, as the effects are using `<img>` elements and css transforms instead of `background-image` / `backgrouns-size: contain or cover` for performance reasons. If you have any questions or run into issues with this constraint, I recommend reading through the original [codrops article](http://tympanus.net/codrops/2014/06/11/how-to-create-a-tiled-background-slideshow) thoroughly.
 

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -18,16 +18,10 @@ const images = [
   image6
 ]
 
-const props = {
-  images,
-  // startAt: 0,
-  onChange: ({ index, image }) => console.log('changed image', { index, image })
-}
-
 export default class App extends Component {
   render () {
     return (
-      <ReactBackgroundSlideshow {...props} />
+      <ReactBackgroundSlideshow images={images} />
     )
   }
 }

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -18,10 +18,16 @@ const images = [
   image6
 ]
 
+const props = {
+  images,
+  // startAt: 0,
+  onChange: ({ index, image }) => console.log('changed image', { index, image })
+}
+
 export default class App extends Component {
   render () {
     return (
-      <ReactBackgroundSlideshow images={images} />
+      <ReactBackgroundSlideshow {...props} />
     )
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,11 @@ export default class ReactBackgroundSlideshow extends Component {
   state = {
     isAnimating: false,
     direction: 'next',
-    current: this.props.startAt || (Math.random() * this.props.images.length | 0),
+    current: (
+      typeof this.props.startAt !== 'undefined' ?
+        this.props.startAt :
+        (Math.random() * this.props.images.length | 0)
+    ),
     effect: Math.random() * 3 | 0
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,9 @@ export default class ReactBackgroundSlideshow extends Component {
     disableClick: PropTypes.bool,
     disableInterval: PropTypes.bool,
     animationDelay: PropTypes.number,
-    alt: PropTypes.string
+    alt: PropTypes.string,
+    onChange: PropTypes.func,
+    startAt: PropTypes.number,
   }
 
   static defaultProps = {
@@ -36,7 +38,7 @@ export default class ReactBackgroundSlideshow extends Component {
   state = {
     isAnimating: false,
     direction: 'next',
-    current: Math.random() * this.props.images.length | 0,
+    current: this.props.startAt || (Math.random() * this.props.images.length | 0),
     effect: Math.random() * 3 | 0
   }
 
@@ -227,6 +229,12 @@ export default class ReactBackgroundSlideshow extends Component {
       isAnimating: false,
       current: this._getNextPanel()
     }, () => {
+      const { onChange, images = [] } = this.props
+      const { current } = this.state
+      const image = images[current]
+      if (onChange) {
+        onChange({ index: current, image })
+      }
       this._isAnimating = false
       this._resetTransitionTimeout()
     })


### PR DESCRIPTION
### Short Description

Adds the ability to specify starting index and a callback on transition completion.

### Use case

I use this component to make a simple page with little to no content on it shine. It is fantastic and easy to use. One problem I am encountering is that I want to be able to know what image is being shown by other components. 

When using it in conjunction with other components we may want to have communication between the slideshow and a state management (such as [redux](https://redux.js.org/)). I think this would be useful when wanting to maintain the currently shown background image in state. Exposing a callback allows us to use an action to update this information. This allows other components to act differently based upon which image is shown. 

### Example

```js
import React, { Component } from 'react'

import ReactBackgroundSlideshow from 'react-background-slideshow'

import image1 from './assets/001.jpg'
import image2 from './assets/002.jpg'
import image3 from './assets/003.jpg'
import image4 from './assets/004.jpg'
import image5 from './assets/005.jpg'
import image6 from './assets/006.jpg'

const images = [
  image1,
  image2,
  image3,
  image4,
  image5,
  image6
]

const params = {
  images,
  onChange: (attrs) => console.log('image changed', attrs),
  startAt: 3,
}

export default class App extends Component {
  render () {
    return (
      <ReactBackgroundSlideshow {...params} />
    )
  }
}
```
![image](https://user-images.githubusercontent.com/20171265/43869840-a1d1eb88-9b42-11e8-882e-373f90f9d23c.png)
